### PR TITLE
Compatibility with hecs-0.10.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ repository = "https://github.com/ten3roberts/hecs-schedule"
 [dependencies]
 anyhow = "1.0.58"
 atomic_refcell = "0.1.8"
-hecs = { version = "0.7.7", features = [ "macros" ] }
+hecs = { version = "0.10.3", features = [ "macros" ] }
 rayon = { version = "1.5.3", optional = true }
 smallvec = "1.9.0"
 thiserror = "1.0.31"

--- a/src/query.rs
+++ b/src/query.rs
@@ -1,7 +1,7 @@
 use std::any::type_name;
 
 use crate::{Error, Result};
-use hecs::{Entity, Query, QueryItem};
+use hecs::{Entity, Query};
 
 /// Wraps the bulting QueryOne with a Result containing the entity and component instead of option
 pub struct QueryOne<'a, Q: Query> {
@@ -21,7 +21,7 @@ impl<'a, Q: Query> QueryOne<'a, Q> {
     /// Panics if called more than once or if it would construct a borrow that clashes with another
     /// pre-existing borrow.
     // Note that this uses self's lifetime, not 'a, for soundness.
-    pub fn get(&mut self) -> Result<QueryItem<Q>> {
+    pub fn get(&mut self) -> Result<Q::Item<'_>> {
         match self.query.get() {
             Some(val) => Ok(val),
             None => Err(Error::UnsatisfiedQuery(self.entity, type_name::<Q>())),

--- a/src/subworld.rs
+++ b/src/subworld.rs
@@ -92,7 +92,7 @@ impl<'w, A: 'w + Deref<Target = World>, T: ComponentBorrow> SubWorldRaw<A, T> {
             });
         }
 
-        match self.world.get(entity) {
+        match self.world.get::<&C>(entity) {
             Ok(val) => Ok(val),
             Err(hecs::ComponentError::NoSuchEntity) => Err(Error::NoSuchEntity(entity)),
             Err(hecs::ComponentError::MissingComponent(name)) => {
@@ -112,7 +112,7 @@ impl<'w, A: 'w + Deref<Target = World>, T: ComponentBorrow> SubWorldRaw<A, T> {
             });
         }
 
-        match self.world.get_mut(entity) {
+        match self.world.get::<&mut C>(entity) {
             Ok(val) => Ok(val),
             Err(hecs::ComponentError::NoSuchEntity) => Err(Error::NoSuchEntity(entity)),
             Err(hecs::ComponentError::MissingComponent(name)) => {

--- a/src/subworld_impls.rs
+++ b/src/subworld_impls.rs
@@ -215,7 +215,7 @@ impl GenericWorld for World {
     }
 
     fn try_get<C: Component>(&self, entity: Entity) -> Result<hecs::Ref<C>> {
-        match self.get(entity) {
+        match self.get::<&C>(entity) {
             Ok(val) => Ok(val),
             Err(hecs::ComponentError::NoSuchEntity) => Err(Error::NoSuchEntity(entity)),
             Err(hecs::ComponentError::MissingComponent(name)) => {
@@ -225,7 +225,7 @@ impl GenericWorld for World {
     }
 
     fn try_get_mut<C: Component>(&self, entity: Entity) -> Result<hecs::RefMut<C>> {
-        match self.get_mut(entity) {
+        match self.get::<&mut C>(entity) {
             Ok(val) => Ok(val),
             Err(hecs::ComponentError::NoSuchEntity) => Err(Error::NoSuchEntity(entity)),
             Err(hecs::ComponentError::MissingComponent(name)) => {


### PR DESCRIPTION
This mostly:
* moves `QueryItem` to `Q::Item`
* moves `get` and `get_mut` to get::<&[mut]>
* adds lifetimes to match up with hecs additions